### PR TITLE
feat: Add new support to Struct migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Run poe help for more info
 * **[Raúl Pedraza León](https://github.com/r-pedraza)**
 * **[Jorge Revuelta](https://github.com/minuscorp)**
 * **[Sebastián Varela](https://github.com/sebastianvarela)**
+* **[David Martínez García](https://github.com/daviwiki)**
 
 ## License
 

--- a/Sources/PoEditorParser/CodeKeeper.swift
+++ b/Sources/PoEditorParser/CodeKeeper.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+protocol CodeKeeper<Handle> {
+    associatedtype Handle
+    func append(_ content: String)
+    func build() -> Handle
+}
+
+class StringKeeper: CodeKeeper {
+    typealias Handle = String
+    private var contents: [String] = []
+
+    func append(_ content: String) {
+        contents.append(content)
+    }
+
+    func build() -> String {
+        contents.joined(separator: "\n")
+    }
+}
+
+class FileHandleKeeper: CodeKeeper {
+    typealias Handle = FileHandle
+    private let handle: FileHandle
+
+    init(handle: FileHandle) {
+        self.handle = handle
+    }
+
+    func append(_ content: String) {
+        handle.write(content.data(using: .utf8)!)
+    }
+
+    func build() -> FileHandle {
+        handle
+    }
+}

--- a/Sources/PoEditorParser/Constants.swift
+++ b/Sources/PoEditorParser/Constants.swift
@@ -11,7 +11,7 @@ enum POEConstants {
 
     """
 
-    static let version = "2.0.5"
+    static let version = "2.0.4"
 
     static func literalsStructHeader(name: String) -> String { "public struct \(name) {\n" }
     static func literalsStructStaticTableName(name: String?) -> String {

--- a/Sources/PoEditorParser/Constants.swift
+++ b/Sources/PoEditorParser/Constants.swift
@@ -11,7 +11,7 @@ enum POEConstants {
 
     """
 
-    static let version = "2.0.4"
+    static let version = "2.0.5"
 
     static func literalsStructHeader(name: String) -> String { "public struct \(name) {\n" }
     static func literalsStructStaticTableName(name: String?) -> String {

--- a/Sources/PoEditorParser/SwiftCodeGenerator.swift
+++ b/Sources/PoEditorParser/SwiftCodeGenerator.swift
@@ -4,49 +4,12 @@ public protocol SwiftCodeGenerator {
     func generateCode(translations: [Translation])
 }
 
-protocol CodeKeeper<Handle> {
-    associatedtype Handle
-    func append(_ content: String)
-    func build() -> Handle
-}
-
-class StringKeeper: CodeKeeper {
-    typealias Handle = String
-    private var contents: [String] = []
-    
-    func append(_ content: String) {
-        contents.append(content)
-    }
-    
-    func build() -> String {
-        return contents.joined(separator: "\n")
-    }
-}
-
-class FileHandleKeeper: CodeKeeper {
-    typealias Handle = FileHandle
-    private let handle: FileHandle
-    
-    init(handle: FileHandle) {
-        self.handle = handle
-    }
-    
-    func append(_ content: String) {
-        handle.write(content.data(using: .utf8)!)
-    }
-    
-    func build() -> FileHandle {
-        handle
-    }
-}
-
 class StructCodeGenerator: SwiftCodeGenerator {
-    
     let keeper: any CodeKeeper
     let typeName: String
     let tableName: String?
     let outputFormat: OutputFormat
-    
+
     init(
         keeper: any CodeKeeper,
         typeName: String,
@@ -58,32 +21,32 @@ class StructCodeGenerator: SwiftCodeGenerator {
         self.tableName = tableName
         self.outputFormat = outputFormat
     }
-    
+
     func generateCode(translations: [Translation]) {
         // File Header
         keeper.append(POEConstants.fileHeader)
         keeper.append(POEConstants.methodOrVariableSeparator)
-        
+
         // File contents
         keeper.append(
-        """
+            """
         public struct \(typeName): Hashable, Equatable {
             public let key: String
-            public let parameters: [String: String] 
-        
+            public let parameters: [String: String]
+
             public init(
-                key: String, 
+                key: String,
                 parameters: [String: String] = [:]
             ) {
                 self.key = key
                 self.parameters = parameters
             }
-            
+
             public func hash(into hasher: inout Hasher) {
                 hasher.combine(key)
                 hasher.combine(parameters)
             }
-        
+
             public func parsed(value: String) -> String {
                 var result = value
                 for (placeholder, replacement) in parameters {
@@ -94,34 +57,33 @@ class StructCodeGenerator: SwiftCodeGenerator {
         }
         """
         )
-        
+
         keeper.append(POEConstants.methodOrVariableSeparator)
         keeper.append(POEConstants.methodOrVariableSeparator)
         keeper.append("public extension \(typeName) {")
         keeper.append(POEConstants.methodOrVariableSeparator)
-        
+
         for (index, translation) in translations.enumerated() {
             keeper.append(translation.swiftStaticFuncCode)
             if index < translations.count - 1 {
                 keeper.append(POEConstants.methodOrVariableSeparator)
             }
         }
-        
+
         keeper.append(POEConstants.methodOrVariableSeparator)
         keeper.append("}") // Close extension
-        
+
         // File close
         keeper.append(POEConstants.fileFooter)
     }
 }
 
 class EnumCodeGenerator: SwiftCodeGenerator {
-    
     let keeper: any CodeKeeper
     let typeName: String
     let tableName: String?
     let outputFormat: OutputFormat
-    
+
     init(
         keeper: any CodeKeeper,
         typeName: String,
@@ -133,11 +95,11 @@ class EnumCodeGenerator: SwiftCodeGenerator {
         self.tableName = tableName
         self.outputFormat = outputFormat
     }
-    
+
     func generateCode(translations: [Translation]) {
         // File Header
         keeper.append(POEConstants.fileHeader)
-        
+
         // File contents
         keeper.append(POEConstants.literalsEnumHeader(keysName: typeName))
         for (index, translation) in translations.enumerated() {
@@ -148,7 +110,7 @@ class EnumCodeGenerator: SwiftCodeGenerator {
         }
         keeper.append(POEConstants.methodOrVariableSeparator)
         keeper.append(POEConstants.methodOrVariableSeparator)
-        
+
         keeper.append(POEConstants.literalsEnumValueFuncStart)
         for translation in translations {
             keeper.append(translation.swiftEnumCaseForValue)
@@ -158,9 +120,9 @@ class EnumCodeGenerator: SwiftCodeGenerator {
             keeper.append(POEConstants.literalsEnumDefaultCase)
         }
         keeper.append(POEConstants.literalsEnumValueFuncEnd)
-        
+
         keeper.append(POEConstants.methodOrVariableSeparator)
-        
+
         keeper.append(POEConstants.literalsEnumStringKeyStart)
         for translation in translations {
             keeper.append(translation.swiftEnumCaseForKey)
@@ -170,9 +132,9 @@ class EnumCodeGenerator: SwiftCodeGenerator {
             keeper.append(POEConstants.literalsEnumDefaultCase)
         }
         keeper.append(POEConstants.literalsEnumStringKeyEnd)
-        
+
         keeper.append(POEConstants.literalsEnumFooter)
-        
+
         // Filoe close
         keeper.append(POEConstants.fileFooter)
     }
@@ -183,7 +145,7 @@ public class StringCodeGenerator: SwiftCodeGenerator {
     let typeName: String
     let tableName: String?
     let outputFormat: OutputFormat
-    
+
     var codeGenerator: any SwiftCodeGenerator {
         switch outputFormat {
         case .struct:
@@ -193,6 +155,7 @@ public class StringCodeGenerator: SwiftCodeGenerator {
                 tableName: tableName,
                 outputFormat: outputFormat
             )
+
         case .enum:
             return EnumCodeGenerator(
                 keeper: keeper,
@@ -220,12 +183,11 @@ public class StringCodeGenerator: SwiftCodeGenerator {
 }
 
 public class FileCodeGenerator: SwiftCodeGenerator {
-    
     let keeper: any CodeKeeper
     let typeName: String
     let tableName: String?
     let outputFormat: OutputFormat
-    
+
     var codeGenerator: any SwiftCodeGenerator {
         switch outputFormat {
         case .struct:
@@ -235,6 +197,7 @@ public class FileCodeGenerator: SwiftCodeGenerator {
                 tableName: tableName,
                 outputFormat: outputFormat
             )
+
         case .enum:
             return EnumCodeGenerator(
                 keeper: keeper,
@@ -244,7 +207,7 @@ public class FileCodeGenerator: SwiftCodeGenerator {
             )
         }
     }
-    
+
     public init(
         fileHandle: FileHandle,
         typeName: String,
@@ -256,7 +219,7 @@ public class FileCodeGenerator: SwiftCodeGenerator {
         self.tableName = tableName
         self.outputFormat = outputFormat
     }
-    
+
     public func generateCode(translations: [Translation]) {
         codeGenerator.generateCode(translations: translations)
     }

--- a/Sources/PoEditorParser/SwiftCodeGenerator.swift
+++ b/Sources/PoEditorParser/SwiftCodeGenerator.swift
@@ -4,131 +4,260 @@ public protocol SwiftCodeGenerator {
     func generateCode(translations: [Translation])
 }
 
-public class StringCodeGenerator: SwiftCodeGenerator {
-    var generatedResult = ""
+protocol CodeKeeper<Handle> {
+    associatedtype Handle
+    func append(_ content: String)
+    func build() -> Handle
+}
+
+class StringKeeper: CodeKeeper {
+    typealias Handle = String
+    private var contents: [String] = []
+    
+    func append(_ content: String) {
+        contents.append(content)
+    }
+    
+    func build() -> String {
+        return contents.joined(separator: "\n")
+    }
+}
+
+class FileHandleKeeper: CodeKeeper {
+    typealias Handle = FileHandle
+    private let handle: FileHandle
+    
+    init(handle: FileHandle) {
+        self.handle = handle
+    }
+    
+    func append(_ content: String) {
+        handle.write(content.data(using: .utf8)!)
+    }
+    
+    func build() -> FileHandle {
+        handle
+    }
+}
+
+class StructCodeGenerator: SwiftCodeGenerator {
+    
+    let keeper: any CodeKeeper
     let typeName: String
     let tableName: String?
     let outputFormat: OutputFormat
+    
+    init(
+        keeper: any CodeKeeper,
+        typeName: String,
+        tableName: String?,
+        outputFormat: OutputFormat
+    ) {
+        self.keeper = keeper
+        self.typeName = typeName
+        self.tableName = tableName
+        self.outputFormat = outputFormat
+    }
+    
+    func generateCode(translations: [Translation]) {
+        // File Header
+        keeper.append(POEConstants.fileHeader)
+        keeper.append(POEConstants.methodOrVariableSeparator)
+        
+        // File contents
+        keeper.append(
+        """
+        public struct \(typeName): Hashable, Equatable {
+            public let key: String
+            public let parameters: [String: String] 
+        
+            public init(
+                key: String, 
+                parameters: [String: String] = [:]
+            ) {
+                self.key = key
+                self.parameters = parameters
+            }
+            
+            public func hash(into hasher: inout Hasher) {
+                hasher.combine(key)
+                hasher.combine(parameters)
+            }
+        
+            public func parsed(value: String) -> String {
+                var result = value
+                for (placeholder, replacement) in parameters {
+                    result = result.replacingOccurrences(of: \"{{\\(placeholder)}}\", with: replacement)
+                }
+                return result
+            }
+        }
+        """
+        )
+        
+        keeper.append(POEConstants.methodOrVariableSeparator)
+        keeper.append(POEConstants.methodOrVariableSeparator)
+        keeper.append("public extension \(typeName) {")
+        keeper.append(POEConstants.methodOrVariableSeparator)
+        
+        for (index, translation) in translations.enumerated() {
+            keeper.append(translation.swiftStaticFuncCode)
+            if index < translations.count - 1 {
+                keeper.append(POEConstants.methodOrVariableSeparator)
+            }
+        }
+        
+        keeper.append(POEConstants.methodOrVariableSeparator)
+        keeper.append("}") // Close extension
+        
+        // File close
+        keeper.append(POEConstants.fileFooter)
+    }
+}
 
-    public init(typeName: String, tableName: String?, outputFormat: OutputFormat) {
+class EnumCodeGenerator: SwiftCodeGenerator {
+    
+    let keeper: any CodeKeeper
+    let typeName: String
+    let tableName: String?
+    let outputFormat: OutputFormat
+    
+    init(
+        keeper: any CodeKeeper,
+        typeName: String,
+        tableName: String?,
+        outputFormat: OutputFormat
+    ) {
+        self.keeper = keeper
+        self.typeName = typeName
+        self.tableName = tableName
+        self.outputFormat = outputFormat
+    }
+    
+    func generateCode(translations: [Translation]) {
+        // File Header
+        keeper.append(POEConstants.fileHeader)
+        
+        // File contents
+        keeper.append(POEConstants.literalsEnumHeader(keysName: typeName))
+        for (index, translation) in translations.enumerated() {
+            keeper.append(translation.swiftEnumCaseCode)
+            if index < translations.count - 1 {
+                keeper.append(POEConstants.methodOrVariableSeparator)
+            }
+        }
+        keeper.append(POEConstants.methodOrVariableSeparator)
+        keeper.append(POEConstants.methodOrVariableSeparator)
+        
+        keeper.append(POEConstants.literalsEnumValueFuncStart)
+        for translation in translations {
+            keeper.append(translation.swiftEnumCaseForValue)
+            keeper.append(POEConstants.methodOrVariableSeparator)
+        }
+        if translations.count > 1_000 {
+            keeper.append(POEConstants.literalsEnumDefaultCase)
+        }
+        keeper.append(POEConstants.literalsEnumValueFuncEnd)
+        
+        keeper.append(POEConstants.methodOrVariableSeparator)
+        
+        keeper.append(POEConstants.literalsEnumStringKeyStart)
+        for translation in translations {
+            keeper.append(translation.swiftEnumCaseForKey)
+            keeper.append(POEConstants.methodOrVariableSeparator)
+        }
+        if translations.count > 1_000 {
+            keeper.append(POEConstants.literalsEnumDefaultCase)
+        }
+        keeper.append(POEConstants.literalsEnumStringKeyEnd)
+        
+        keeper.append(POEConstants.literalsEnumFooter)
+        
+        // Filoe close
+        keeper.append(POEConstants.fileFooter)
+    }
+}
+
+public class StringCodeGenerator: SwiftCodeGenerator {
+    let keeper: any CodeKeeper
+    let typeName: String
+    let tableName: String?
+    let outputFormat: OutputFormat
+    
+    var codeGenerator: any SwiftCodeGenerator {
+        switch outputFormat {
+        case .struct:
+            return StructCodeGenerator(
+                keeper: keeper,
+                typeName: typeName,
+                tableName: tableName,
+                outputFormat: outputFormat
+            )
+        case .enum:
+            return EnumCodeGenerator(
+                keeper: keeper,
+                typeName: typeName,
+                tableName: tableName,
+                outputFormat: outputFormat
+            )
+        }
+    }
+
+    public init(
+        typeName: String,
+        tableName: String?,
+        outputFormat: OutputFormat
+    ) {
+        keeper = StringKeeper()
         self.typeName = typeName
         self.tableName = tableName
         self.outputFormat = outputFormat
     }
 
     public func generateCode(translations: [Translation]) {
-        generatedResult += POEConstants.fileHeader
-
-        switch outputFormat {
-        case .struct:
-            generatedResult += POEConstants.literalsStructHeader(name: typeName)
-            generatedResult += POEConstants.literalsStructStaticTableName(name: tableName)
-            for translation in translations {
-                generatedResult += translation.swiftStaticFuncCode
-                generatedResult += POEConstants.methodOrVariableSeparator
-            }
-            generatedResult += POEConstants.literalsStructFooter
-
-        case .enum:
-            generatedResult += POEConstants.literalsEnumHeader(keysName: typeName)
-            for (index, translation) in translations.enumerated() {
-                generatedResult += translation.swiftEnumCaseCode
-                if index < translations.count - 1 { generatedResult += POEConstants.methodOrVariableSeparator }
-            }
-            generatedResult += POEConstants.methodOrVariableSeparator
-            generatedResult += POEConstants.methodOrVariableSeparator
-
-            generatedResult += POEConstants.literalsEnumValueFuncStart
-            for translation in translations {
-                generatedResult += translation.swiftEnumCaseForValue
-                generatedResult += POEConstants.methodOrVariableSeparator
-            }
-            if translations.count > 1_000 {
-                generatedResult += POEConstants.literalsEnumDefaultCase
-            }
-            generatedResult += POEConstants.literalsEnumValueFuncEnd
-
-            generatedResult += POEConstants.methodOrVariableSeparator
-
-            generatedResult += POEConstants.literalsEnumStringKeyStart
-            for translation in translations {
-                generatedResult += translation.swiftEnumCaseForKey
-                generatedResult += POEConstants.methodOrVariableSeparator
-            }
-            if translations.count > 1_000 {
-                generatedResult += POEConstants.literalsEnumDefaultCase
-            }
-            generatedResult += POEConstants.literalsEnumStringKeyEnd
-
-            generatedResult += POEConstants.literalsEnumFooter
-        }
-
-        generatedResult += POEConstants.fileFooter
+        codeGenerator.generateCode(translations: translations)
     }
 }
 
 public class FileCodeGenerator: SwiftCodeGenerator {
-    let fileHandle: FileHandle
+    
+    let keeper: any CodeKeeper
     let typeName: String
     let tableName: String?
     let outputFormat: OutputFormat
-
-    public init(fileHandle: FileHandle, typeName: String, tableName: String?, outputFormat: OutputFormat) {
-        self.fileHandle = fileHandle
+    
+    var codeGenerator: any SwiftCodeGenerator {
+        switch outputFormat {
+        case .struct:
+            return StructCodeGenerator(
+                keeper: keeper,
+                typeName: typeName,
+                tableName: tableName,
+                outputFormat: outputFormat
+            )
+        case .enum:
+            return EnumCodeGenerator(
+                keeper: keeper,
+                typeName: typeName,
+                tableName: tableName,
+                outputFormat: outputFormat
+            )
+        }
+    }
+    
+    public init(
+        fileHandle: FileHandle,
+        typeName: String,
+        tableName: String?,
+        outputFormat: OutputFormat
+    ) {
+        keeper = FileHandleKeeper(handle: fileHandle)
         self.typeName = typeName
         self.tableName = tableName
         self.outputFormat = outputFormat
     }
-
+    
     public func generateCode(translations: [Translation]) {
-        fileHandle += POEConstants.fileHeader
-
-        switch outputFormat {
-        case .struct:
-            fileHandle += POEConstants.literalsStructHeader(name: typeName)
-            fileHandle += POEConstants.literalsStructStaticTableName(name: tableName)
-            for (index, translation) in translations.enumerated() {
-                fileHandle += translation.swiftStaticFuncCode
-                if index < translations.count - 1 { fileHandle += POEConstants.methodOrVariableSeparator }
-            }
-            fileHandle += POEConstants.literalsStructFooter
-
-        case .enum:
-            fileHandle += POEConstants.literalsEnumHeader(keysName: typeName)
-            for (index, translation) in translations.enumerated() {
-                fileHandle += translation.swiftEnumCaseCode
-                if index < translations.count - 1 { fileHandle += POEConstants.methodOrVariableSeparator }
-            }
-            fileHandle += POEConstants.methodOrVariableSeparator
-            fileHandle += POEConstants.methodOrVariableSeparator
-
-            fileHandle += POEConstants.literalsEnumValueFuncStart
-            for translation in translations {
-                fileHandle += translation.swiftEnumCaseForValue
-                fileHandle += POEConstants.methodOrVariableSeparator
-            }
-            if translations.count > 1_000 {
-                fileHandle += POEConstants.literalsEnumDefaultCase
-            }
-            fileHandle += POEConstants.literalsEnumValueFuncEnd
-
-            fileHandle += POEConstants.methodOrVariableSeparator
-
-            fileHandle += POEConstants.literalsEnumStringKeyStart
-            for translation in translations {
-                fileHandle += translation.swiftEnumCaseForKey
-                fileHandle += POEConstants.methodOrVariableSeparator
-            }
-            if translations.count > 1_000 {
-                fileHandle += POEConstants.literalsEnumDefaultCase
-            }
-            fileHandle += POEConstants.literalsEnumStringKeyEnd
-
-            fileHandle += POEConstants.literalsEnumFooter
-        }
-
-        fileHandle += POEConstants.fileFooter
-
-        fileHandle.closeFile()
+        codeGenerator.generateCode(translations: translations)
     }
 }

--- a/Sources/PoEditorParser/Translation.swift
+++ b/Sources/PoEditorParser/Translation.swift
@@ -36,13 +36,13 @@ public struct Translation: Comparable {
 
     public var swiftEnumCaseCode: String {
         if variables.isEmpty {
-            return "\tcase \(prettyKey)"
+            return "\tcase \(keySafeForCodeMethod)"
         }
         let parameters = variables
             .map { $0.type.swiftParameter(key: $0.parameterKey) }
             .joined(separator: ", ")
 
-        return "\tcase \(prettyKey)(\(parameters))"
+        return "\tcase \(keySafeForCodeMethod)(\(parameters))"
     }
 
     public var swiftEnumCaseForValue: String {
@@ -54,22 +54,29 @@ public struct Translation: Comparable {
     }
 
     public var swiftEnumCaseForKey: String {
-        "\t\tcase .\(prettyKey): return \"\(key)\""
+        "\t\tcase .\(keySafeForCodeMethod): return \"\(key)\""
     }
 
-    private var prettyKey: String {
+    private var keySafeForCodeMethod: String {        
         switch keysFormat {
         case .upperCamelCase:
-            return key.capitalized.replacingOccurrences(of: "_", with: "")
+            return key.capitalized
+                .replacingOccurrences(of: "_", with: "")
+                .replacingOccurrences(of: "[", with: "")
+                .replacingOccurrences(of: "]", with: "")
+                .replacingOccurrences(of: "|", with: "")
 
         case .lowerCamelCase:
             return (key.prefix(1).lowercased() + key.capitalized.dropFirst())
                 .replacingOccurrences(of: "_", with: "")
+                .replacingOccurrences(of: "[", with: "")
+                .replacingOccurrences(of: "]", with: "")
+                .replacingOccurrences(of: "|", with: "")
         }
     }
 
     private func generateEnumCaseWithoutVariables() -> String {
-        "\t\tcase .\(prettyKey): return value"
+        "\t\tcase .\(keySafeForCodeMethod): return value"
     }
 
     private func generateEnumCaseWithVariables() -> String {
@@ -86,7 +93,7 @@ public struct Translation: Comparable {
                 return ".replacingOccurrences(of: \"{{\(variable.parameterKey)}}\", with: \(variable.parameterKey.snakeCased()))"
             }
             .joined(separator: "\n\t\t\t")
-        return "\t\tcase .\(prettyKey)(\(parameters)): return value\n\t\t\t\(localizedArguments)"
+        return "\t\tcase .\(keySafeForCodeMethod)(\(parameters)): return value\n\t\t\t\(localizedArguments)"
     }
 
     private func generateFuncWithoutVariables() -> String {
@@ -94,8 +101,8 @@ public struct Translation: Comparable {
          static let key: StringsUIKey = StringsUIKey(key: "key_id")
          */
         """
-        \(commentKey(maxLength: 70))
-            static let \(prettyKey): \(typeName) = \(typeName)(key: \"\(key)\")
+        \(commentKey(maxLength: 700))
+            static let \(keySafeForCodeMethod): \(typeName) = \(typeName)(key: \"\(key)\")
         """
     }
 
@@ -126,34 +133,34 @@ public struct Translation: Comparable {
         }
 
         return """
-        \(commentKey(maxLength: 70))
-            static func \(prettyKey)(\(parameters)) -> \(typeName) {
+        \(commentKey(maxLength: 700))
+            static func \(keySafeForCodeMethod)(\(parameters)) -> \(typeName) {
                 .init(key: \"\(key)\", parameters: \(localizedArgumentsString))
             }
         """
     }
 
     public static func < (lhs: Translation, rhs: Translation) -> Bool {
-        lhs.prettyKey < rhs.prettyKey
+        lhs.keySafeForCodeMethod < rhs.keySafeForCodeMethod
     }
 
     public static func == (lhs: Translation, rhs: Translation) -> Bool {
-        lhs.prettyKey == rhs.prettyKey
+        lhs.keySafeForCodeMethod == rhs.keySafeForCodeMethod
     }
 
     private func commentKey(maxLength: Int) -> String {
-        let keyValue: String = {
-            if rawValue.count <= maxLength {
-                return rawValue
+        let truncatedValue: String = {
+            if value.count <= maxLength {
+                return value
             }
-            let truncated = String(rawValue.prefix(maxLength - 3))
+            let truncated = String(value.prefix(maxLength - 3))
             return "\(truncated)..."
         }()
 
         if variables.isEmpty {
             return """
                 /// Returns Literal instance for `\(key)` key.
-                /// - Example: \(keyValue)
+                /// - Example: \(truncatedValue)
             """
         } else {
             let parameters = variables
@@ -163,7 +170,7 @@ public struct Translation: Comparable {
                 /// Returns Literal instance for `\(key)` key.
                 /// - Parameters:
             \(parameters)
-                /// - Example: \(keyValue)
+                /// - Example: \(truncatedValue)
             """
         }
     }

--- a/Sources/PoEditorParser/Translation.swift
+++ b/Sources/PoEditorParser/Translation.swift
@@ -93,7 +93,8 @@ public struct Translation: Comparable {
         /*
          static let key: StringsUIKey = StringsUIKey(key: "key_id")
          */
-        "\tstatic let \(prettyKey): \(typeName) = \(typeName)(key: \"\(key)\")"
+        let comment = truncatedComment(from: rawValue, maxLength: 70)
+        return "\t/// \(comment)\n\tstatic let \(prettyKey): \(typeName) = \(typeName)(key: \"\(key)\")"
     }
 
     private func generateFuncWithVariables() -> String {
@@ -122,7 +123,9 @@ public struct Translation: Comparable {
             return "[\(result.joined(separator: ", "))]"
         }
         
+        let comment = truncatedComment(from: rawValue, maxLength: 70)
         return """
+            \t/// \(comment)
             static func \(prettyKey)(\(parameters)) -> \(typeName) {
                 .init(key: \"\(key)\", parameters: \(localizedArgumentsString))
             }
@@ -135,6 +138,15 @@ public struct Translation: Comparable {
 
     public static func == (lhs: Translation, rhs: Translation) -> Bool {
         lhs.prettyKey == rhs.prettyKey
+    }
+
+    private func truncatedComment(from text: String, maxLength: Int) -> String {
+        let cleanText = text.replacingOccurrences(of: "{{", with: "").replacingOccurrences(of: "}}", with: "")
+        if cleanText.count <= maxLength {
+            return cleanText
+        }
+        let truncated = String(cleanText.prefix(maxLength - 3))
+        return "\(truncated)..."
     }
 }
 

--- a/Sources/PoEditorParser/Translation.swift
+++ b/Sources/PoEditorParser/Translation.swift
@@ -93,28 +93,30 @@ public struct Translation: Comparable {
         /*
          static let key: StringsUIKey = StringsUIKey(key: "key_id")
          */
-        let comment = truncatedComment(from: rawValue, maxLength: 70)
-        return "\t/// \(comment)\n\tstatic let \(prettyKey): \(typeName) = \(typeName)(key: \"\(key)\")"
+        """
+        \(commentKey(maxLength: 70))
+            static let \(prettyKey): \(typeName) = \(typeName)(key: \"\(key)\")
+        """
     }
 
     private func generateFuncWithVariables() -> String {
         /*
          static func key(parameter1: String) -> StringsUIKey {
-            .init(key: "key", parameters: ["parameter1": parameter1])
+         .init(key: "key", parameters: ["parameter1": parameter1])
          }
          */
         let parameters = variables
             .map { $0.type.swiftParameter(key: $0.parameterKey) }
             .joined(separator: ", ")
-        
+
         let localizedArguments = variables
             .map { variable in
                 (
                     key: "\"\(variable.parameterKey)\"",
-                    value: variable.toParamterValue()
+                    value: variable.toParameterValue()
                 )
             }
-            
+
         var localizedArgumentsString: String {
             var result: [String] = []
             for (key, value) in localizedArguments {
@@ -122,10 +124,9 @@ public struct Translation: Comparable {
             }
             return "[\(result.joined(separator: ", "))]"
         }
-        
-        let comment = truncatedComment(from: rawValue, maxLength: 70)
+
         return """
-            \t/// \(comment)
+        \(commentKey(maxLength: 70))
             static func \(prettyKey)(\(parameters)) -> \(typeName) {
                 .init(key: \"\(key)\", parameters: \(localizedArgumentsString))
             }
@@ -140,21 +141,40 @@ public struct Translation: Comparable {
         lhs.prettyKey == rhs.prettyKey
     }
 
-    private func truncatedComment(from text: String, maxLength: Int) -> String {
-        let cleanText = text.replacingOccurrences(of: "{{", with: "").replacingOccurrences(of: "}}", with: "")
-        if cleanText.count <= maxLength {
-            return cleanText
+    private func commentKey(maxLength: Int) -> String {
+        let keyValue: String = {
+            if rawValue.count <= maxLength {
+                return rawValue
+            }
+            let truncated = String(rawValue.prefix(maxLength - 3))
+            return "\(truncated)..."
+        }()
+
+        if variables.isEmpty {
+            return """
+                /// Returns Literal instance for `\(key)` key.
+                /// - Example: \(keyValue)
+            """
+        } else {
+            let parameters = variables
+                .map { "    ///     - \($0.parameterKey): Replace *{{\($0.parameterKey)}}* with the given value in \($0.type.swiftType)" }
+                .joined(separator: "\n")
+            return """
+                /// Returns Literal instance for `\(key)` key.
+                /// - Parameters:
+            \(parameters)
+                /// - Example: \(keyValue)
+            """
         }
-        let truncated = String(cleanText.prefix(maxLength - 3))
-        return "\(truncated)..."
     }
 }
 
 private extension Variable {
-    func toParamterValue() -> String {
+    func toParameterValue() -> String {
         switch type {
         case .textual:
             return parameterKey.snakeCased()
+
         case .numeric:
             let value = "String(format: \"\(type.localizedRepresentation)\", \(parameterKey.snakeCased()))"
             return value

--- a/Sources/PoEditorParser/Translation.swift
+++ b/Sources/PoEditorParser/Translation.swift
@@ -57,7 +57,7 @@ public struct Translation: Comparable {
         "\t\tcase .\(keySafeForCodeMethod): return \"\(key)\""
     }
 
-    private var keySafeForCodeMethod: String {        
+    private var keySafeForCodeMethod: String {
         switch keysFormat {
         case .upperCamelCase:
             return key.capitalized

--- a/Sources/PoEditorParser/Translation.swift
+++ b/Sources/PoEditorParser/Translation.swift
@@ -91,33 +91,42 @@ public struct Translation: Comparable {
 
     private func generateFuncWithoutVariables() -> String {
         /*
-         static var Welcome: String {
-         return NSLocalizedString()
-         }
+         static let key: StringsUIKey = StringsUIKey(key: "key_id")
          */
-        "\tpublic static var \(prettyKey): String {\n\t\treturn NSLocalizedString(\"\(key)\", tableName: \(typeName).tableName, comment: \"\")\n\t}\n"
+        "\tstatic let \(prettyKey): \(typeName) = \(typeName)(key: \"\(key)\")"
     }
 
     private func generateFuncWithVariables() -> String {
         /*
-         static func ReadBooksKey(readNumber: Int) -> String {
-         return ""
+         static func key(parameter1: String) -> StringsUIKey {
+            .init(key: "key", parameters: ["parameter1": parameter1])
          }
          */
         let parameters = variables
             .map { $0.type.swiftParameter(key: $0.parameterKey) }
             .joined(separator: ", ")
+        
         let localizedArguments = variables
             .map { variable in
-                if variable.type != .textual {
-                    let value = "String(format: \"\(variable.type.localizedRepresentation)\", \(variable.parameterKey.snakeCased()))"
-                    return ".replacingOccurrences(of: \"{{\(variable.parameterKey)}}\", with: \(value))"
-                }
-
-                return ".replacingOccurrences(of: \"{{\(variable.parameterKey)}}\", with: \(variable.parameterKey.snakeCased()))"
+                (
+                    key: "\"\(variable.parameterKey)\"",
+                    value: variable.toParamterValue()
+                )
             }
-            .joined(separator: "\n\t\t\t")
-        return "\tpublic static func \(prettyKey)(\(parameters)) -> String {\n\t\treturn NSLocalizedString(\"\(key)\", tableName: \(typeName).tableName, comment: \"\")\n\t\t\t\(localizedArguments)\n\t}\n"
+            
+        var localizedArgumentsString: String {
+            var result: [String] = []
+            for (key, value) in localizedArguments {
+                result.append("\(key): \(value)")
+            }
+            return "[\(result.joined(separator: ", "))]"
+        }
+        
+        return """
+            static func \(prettyKey)(\(parameters)) -> \(typeName) {
+                .init(key: \"\(key)\", parameters: \(localizedArgumentsString))
+            }
+        """
     }
 
     public static func < (lhs: Translation, rhs: Translation) -> Bool {
@@ -126,5 +135,17 @@ public struct Translation: Comparable {
 
     public static func == (lhs: Translation, rhs: Translation) -> Bool {
         lhs.prettyKey == rhs.prettyKey
+    }
+}
+
+private extension Variable {
+    func toParamterValue() -> String {
+        switch type {
+        case .textual:
+            return parameterKey.snakeCased()
+        case .numeric:
+            let value = "String(format: \"\(type.localizedRepresentation)\", \(parameterKey.snakeCased()))"
+            return value
+        }
     }
 }

--- a/Sources/PoEditorParser/VariableType.swift
+++ b/Sources/PoEditorParser/VariableType.swift
@@ -32,7 +32,7 @@ extension VariableType {
 }
 
 extension VariableType {
-    private var swiftType: String {
+    var swiftType: String {
         switch self {
         case .numeric:
             return "Int" // TODO: Decimal types?


### PR DESCRIPTION
### PR's key points
Actually the result file generated when you choose "struct" mode, differs a lot against the "enum" mode. 

We perform a full remake of how parser work:
- Some duplicated logic is now unified in a single algorithm, one for struct mode and another one for enum mode
- Struct mode now generates an interface that match with how enum works so you could switch between both of them without code changes.
 
### How to review this PR?
- Test the generated binary
- You could generate the ragnarok keys (without download any new key) adding the following lane

```
desc 'This lane is intended to generate POEditor UI literals from local files'
    desc 'Parameters: No'
    lane :generate_ui_poeditor do
        flavors = all_flavors()
        selected_flavor = UI.select("Select flavor to generate StringsUIKey:", flavors)
        UI.message "Selected flavor: #{selected_flavor}"
        flavor_folder = parse_folder_target(selected_flavor)
        
        poe_cmd = +"mint run poe"
        poe_cmd << " --onlygenerate YES"
        poe_cmd << " --stringsfile #{flavor_folder}/Shared/Strings/es.lproj/UILocalizable.strings"
        poe_cmd << " --swiftfile #{workspace_path()}/Domain/I18N/StringsUIKey.swift"
        poe_cmd << " --outputformat struct"
        poe_cmd << " --typename StringsUIKey"
        poe_cmd << " --keysformat lowerCamelCase"
        Dir.chdir("..") do
          UI.header "Generating StringsUIKey.swift"
          UI.message "From: #{flavor_folder}/Shared/Strings/es.lproj/UILocalizable.strings"
          sh poe_cmd
        end
        
        UI.success "StringsUIKey.swift generated successfully! ✨"
    end
```
